### PR TITLE
#4 | AnyPublisher<Bool, Never> -> AnyPublisher<Void, PersistentStorageError>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-## [1.0.1]
+## [1.1.0]
 
 ### Changed
+
+- Changed output type for method returning AnyPublisher<Bool, Never> to AnyPublisher<Void, PersistentStorageError>
 - Changed type of returned value from optional type to non-optional for read methods. Marked methods with optional return type as deprecated.
+- Version increased
 
 ## [1.0.0]
 
 ### Added
+
 - Created first version of persistent storage framework
 
 ### Changed
+
 - SPM Support

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "PersistentStorage",
     platforms: [
-        .iOS(.v15), .macOS(.v10_15), .tvOS(.v11), .watchOS(.v4)
+        .iOS(.v15), .macOS(.v11), .tvOS(.v13), .watchOS(.v6)
     ],
     products: [
         .library(

--- a/PersistentStorage/Sources/Data/Repository/PersistentStorage+Deprecated.swift
+++ b/PersistentStorage/Sources/Data/Repository/PersistentStorage+Deprecated.swift
@@ -1,0 +1,163 @@
+import Combine
+import Foundation
+
+// MARK: - Deprecated methods
+extension PersistentStorage {
+    // MARK: - Remove in 2.0.0
+
+    /// Method for removing a value with assigned key from the user defaults storage.
+    ///
+    /// - Parameters:
+    ///     - key: Key that will be assigned to value
+    @available(*, deprecated, message: "This will be removed in 2.0.0. Use the store method that returns AnyPublisher<Void, PersistentStorageError>")
+    @discardableResult
+    public func remove(
+        valueKey: String
+    ) -> AnyPublisher<Bool, Never> {
+        userDefaults.set(
+            nil,
+            forKey: valueKey
+        )
+        log(
+            message: "✅ Successfully removed value with key {\(valueKey)}",
+            for: .debug
+        )
+        // This operation is always successful
+        return Just(true).eraseToAnyPublisher()
+    }
+
+    /// Method for storing a value with assigned key into the user defaults storage.
+    ///
+    /// - Parameters:
+    ///     - value: The value you want to store in
+    ///     - key: Key that will be assigned to value
+    @available(*, deprecated, message: "This will be removed in 2.0.0. Use the store method that returns AnyPublisher<Void, PersistentStorageError>")
+    @discardableResult public func store<T>(
+        _ value: T?,
+        for key: String
+    ) -> AnyPublisher<Bool, Never> {
+        if let persistedValue = userDefaults.value(forKey: key) as? T {
+            log(
+                message: "ℹ️ Rewritten original value {\(persistedValue)} for key {\(key)} while persisting",
+                for: .debug
+            )
+        }
+        log(
+            message: "✅ Successfully persisted value {\(String(describing: value))} for key {\(key)}",
+            for: .debug
+        )
+
+        userDefaults.set(
+            value,
+            forKey: key
+        )
+        // This operation is always successful
+        return Just(true).eraseToAnyPublisher()
+    }
+
+    /// Method for observing a value with given user defaults `KeyPath`.
+    ///
+    /// - Parameters:
+    ///     - keyPath: Specified key represented by user defaults `KeyPath` value.
+    @available(*, deprecated, message: "Use updated version of this method with non-optional return type")
+    public func observe<T>(
+        keyPath: KeyPath<UserDefaults, T?>
+    ) -> AnyPublisher<T?, Never> {
+        userDefaults
+            .publisher(for: keyPath)
+            .handleEvents(
+                receiveOutput: { [weak self] value in
+                    self?.log(
+                        message: "✅ Observing value {\(String(describing: value))}.",
+                        for: .debug
+                    )
+                }
+            )
+            .eraseToAnyPublisher()
+    }
+
+    /// Method for reading a value with given key and type. Result is returned as a publisher.
+    ///
+    /// - Possible failures:
+    ///     - If type resolution with given parameter `valueType` fails, method will return `noValueFoundWithGivenType` failure.
+    ///
+    /// - Parameters:
+    ///     - valueType: The type of value that you wish to read.
+    ///     - valueKey: Key that is assigned to a value that you wish to read.
+    @available(*, deprecated, message: "Use updated version of this method with non-optional return type")
+    public func readWithPublisher<T>(
+        valueType: T.Type,
+        valueKey: String
+    ) -> AnyPublisher<T?, PersistentStorageError> {
+        do {
+            let persistedValue = try getPersistedOptionalValue(
+                valueType: valueType,
+                valueKey: valueKey
+            )
+            return Just(
+                persistedValue
+            )
+            .setFailureType(to: PersistentStorageError.self)
+            .eraseToAnyPublisher()
+        } catch {
+            guard let error = error as? PersistentStorageError else {
+                return Fail(
+                    error: PersistentStorageError.undefined
+                ).eraseToAnyPublisher()
+            }
+            return Fail(
+                error: error
+            ).eraseToAnyPublisher()
+        }
+    }
+
+    /// Method for reading a value with given key and type.
+    ///
+    /// - Possible failures:
+    ///     - If type resolution with given parameter `valueType` fails, method will return `noValueFoundWithGivenType` failure.
+    ///
+    /// - Parameters:
+    ///     - valueType: The type of value that you wish to read.
+    ///     - valueKey: Key that is assigned to a value that you wish to read.
+    @available(*, deprecated, message: "Use updated version of this method with non-optional return type")
+    public func read<T>(
+        valueType: T.Type,
+        valueKey: String
+    ) throws -> T? {
+        try getPersistedOptionalValue(
+            valueType: valueType,
+            valueKey: valueKey
+        )
+    }
+
+    // MARK: - Private methods
+
+    /// TODO
+    @available(*, deprecated, message: "Use updated version of this method with non-optional return type")
+    private func getPersistedOptionalValue<T>(
+        valueType: T.Type,
+        valueKey: String
+    ) throws -> T? {
+        guard let persistedValue = userDefaults.value(forKey: valueKey) as? T else {
+            if userDefaults.value(forKey: valueKey) != nil {
+                log(
+                    message: "❌ Value with given key exists, but method is unable to parse the value with given type.",
+                    for: .failure
+                )
+                throw PersistentStorageError.noValueFoundWithGivenType
+            } else {
+                log(
+                    message: "ℹ️ Value with given key does not exist, returning nil.",
+                    for: .failure
+                )
+                return nil
+            }
+        }
+        log(
+            // swiftlint:disable:next line_length
+            message: "✅ Successfully returned persisted value with key {\(valueKey)} and associated value {\(persistedValue)}",
+            for: .debug
+        )
+        return persistedValue
+    }
+}


### PR DESCRIPTION
Closes #4 

Merge after https://github.com/EtneteraMobile/PersistentStorage/pull/6

- Changed methods that output AnyPublisher<Bool, Never> to AnyPublisher<Void, PersistentStorageError>
- Deprecated copies of those methods, to be removed in version 2.0.0
- Moved Deprecated methods into separate extension
- Added documentation to some methods
- Changed supported version for macOS to v11
- Changed changelog version

For any questions, feel free to ask. 