### PR TITLE
#2 | Removing object for key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed type of returned value from optional type to non-optional for read methods. Marked methods with optional return type as deprecated.
 - Version increased
 
+### Fixed
+
+- Removing value actually removes object for a given key
+
 ## [1.0.0]
 
 ### Added

--- a/PersistentStorage/Sources/Data/Repository/PersistentStorage+Deprecated/MainPersistentStorage+PersistentStorageDeprecated.swift
+++ b/PersistentStorage/Sources/Data/Repository/PersistentStorage+Deprecated/MainPersistentStorage+PersistentStorageDeprecated.swift
@@ -74,6 +74,26 @@ extension MainPersistentStorage: PersistentStorageDeprecated {
             .eraseToAnyPublisher()
     }
 
+    /// Method for reading a value with given key and type.
+    ///
+    /// - Possible failures:
+    ///     - If type resolution with given parameter `valueType` fails, method will return `noValueFoundWithGivenType` failure.
+    ///     - If no value is associated with key given in parameter `valueKey` or its value is nil, the method will return `noValueFound` failure.
+    ///
+    /// - Parameters:
+    ///     - valueType: The type of value that you wish to read.
+    ///     - valueKey: Key that is assigned to a value that you wish to read.
+    @available(*, deprecated, message: "This will be removed in 2.0.0. Use the read method returning AnyPublisher<T, PersistentStorageError>", renamed: "readWithPubliser")
+    public func read<T>(
+        valueType: T.Type,
+        valueKey: String
+    ) throws -> T {
+        try getPersistedValue(
+            valueType: valueType,
+            valueKey: valueKey
+        )
+    }
+
     /// Method for reading a value with given key and type. Result is returned as a publisher.
     ///
     /// - Possible failures:
@@ -131,7 +151,6 @@ extension MainPersistentStorage: PersistentStorageDeprecated {
     // MARK: - Private methods
 
     /// TODO
-    @available(*, deprecated, message: "Use updated version of this method with non-optional return type")
     private func getPersistedOptionalValue<T>(
         valueType: T.Type,
         valueKey: String

--- a/PersistentStorage/Sources/Data/Repository/PersistentStorage+Deprecated/MainPersistentStorage+PersistentStorageDeprecated.swift
+++ b/PersistentStorage/Sources/Data/Repository/PersistentStorage+Deprecated/MainPersistentStorage+PersistentStorageDeprecated.swift
@@ -14,10 +14,7 @@ extension MainPersistentStorage: PersistentStorageDeprecated {
     public func remove(
         valueKey: String
     ) -> AnyPublisher<Bool, Never> {
-        userDefaults.set(
-            nil,
-            forKey: valueKey
-        )
+        userDefaults.removeObject(forKey: valueKey)
         log(
             message: "✅ Successfully removed value with key {\(valueKey)}",
             for: .debug

--- a/PersistentStorage/Sources/Data/Repository/PersistentStorage/MainPersistentStorage.swift
+++ b/PersistentStorage/Sources/Data/Repository/PersistentStorage/MainPersistentStorage.swift
@@ -64,25 +64,6 @@ public class MainPersistentStorage: PersistentStorage {
             .eraseToAnyPublisher()
     }
 
-    /// Method for reading a value with given key and type.
-    ///
-    /// - Possible failures:
-    ///     - If type resolution with given parameter `valueType` fails, method will return `noValueFoundWithGivenType` failure.
-    ///     - If no value is associated with key given in parameter `valueKey` or its value is nil, the method will return `noValueFound` failure.
-    ///
-    /// - Parameters:
-    ///     - valueType: The type of value that you wish to read.
-    ///     - valueKey: Key that is assigned to a value that you wish to read.
-    public func read<T>(
-        valueType: T.Type,
-        valueKey: String
-    ) throws -> T {
-        try getPersistedValue(
-            valueType: valueType,
-            valueKey: valueKey
-        )
-    }
-
     /// Method for reading a value with given key and type. Result is returned as a publisher.
     ///
     /// - Possible failures:

--- a/PersistentStorage/Sources/Data/Repository/PersistentStorage/MainPersistentStorage.swift
+++ b/PersistentStorage/Sources/Data/Repository/PersistentStorage/MainPersistentStorage.swift
@@ -53,10 +53,7 @@ public class MainPersistentStorage: PersistentStorage {
     public func remove(
         valueKey: String
     ) -> AnyPublisher<Void, PersistentStorageError> {
-        userDefaults.set(
-            nil,
-            forKey: valueKey
-        )
+        userDefaults.removeObject(forKey: valueKey)
         log(
             message: "✅ Successfully removed value with key {\(valueKey)}",
             for: .debug


### PR DESCRIPTION
Closes #2 

Merge after #11 

- Removing object for key instead of setting it to nil on `remove`
- Deprecated read without publisher -> this has to be removed in 2.0.0 (Multiple UserDefaults)

For any questions, feel free to ask.